### PR TITLE
A hack to find FFMPEG includes on Fedora 17.

### DIFF
--- a/slowmoVideo/CMakeLists.txt
+++ b/slowmoVideo/CMakeLists.txt
@@ -56,6 +56,7 @@ else(NOT MSYS)
     # libavformat.a(avisynth.o):avisynth.c:(.text+0x6b): undefined reference to `AVIStreamRelease@4'
 endif(NOT MSYS)
 include_directories(${FFMPEG_INCLUDE_DIR})
+include_directories("/usr/include/ffmpeg/")
 link_directories(${FFMPEG_LIBRARY_DIR})
 
 find_package(OpenCV)


### PR DESCRIPTION
This works as temporary solution. Probably it would be better to have some approach like here - https://git.reviewboard.kde.org/r/106153/diff/
