### PR TITLE
Building Shared Libraries against the X11 Library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,6 +241,7 @@ find_package(GLUT)
 find_package(JPEG)
 find_package(PNG)
 find_package(ZLIB)
+find_package(X11)
 
 # Windows: Try to find libraries that could not be found manually in the libs/ directory.
 if(WIN32)
@@ -352,7 +353,7 @@ if (BUILD_FLOW_BUILDER)
     )
 
     add_library(V3D ${ALL_SRC})
-    target_link_libraries(V3D ${GLEW_LIBRARIES})
+    target_link_libraries(V3D ${GLEW_LIBRARIES} X11)
     #install(TARGETS V3D DESTINATION lib)
     add_subdirectory(V3D/Apps)
 endif (BUILD_FLOW_BUILDER)


### PR DESCRIPTION
This pull request adds the X11 library to the set of target_link_libraries .
This allowed me to successfully build the upstream source.

In this review process however I could see that some build configuration options which should be set by the building process are "hard coded" in src/CMakeLists . This file should only set default values and should allow the building process to modify these values.

Another point is that the debian folder is "out of touch" and results in building empty packages.

I believe I will make other pull request about this behaviour.

That was my first pull request on GitHub, so in the early process I may have loose my nerve. I am sorry about that.