### PR TITLE
ffmpeg stderr read aborts on long videos, ffmpeg wait time defaults to 30s

### DIFF
--- a/src/slowmoVideo/lib/videoInfo_sV.cpp
+++ b/src/slowmoVideo/lib/videoInfo_sV.cpp
@@ -43,7 +43,7 @@ VideoInfoSV getInfo(const char filename[])
     args << "/dev/null";
 
     ffmpeg.start(prog, args);
-    ffmpeg.waitForFinished();
+    ffmpeg.waitForFinished(-1);
     QString videoInfo = ffmpeg.readAllStandardError();
     ffmpeg.close();
   


### PR DESCRIPTION
bug: ffmpeg.waitForFinished() waits for 30s 

long videos cause the importer to pass wrong end time to slowmovideo

fix: ffmpeg.waitForFinished(-1)  -> wait forever